### PR TITLE
Better fix extra args parsing and many other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ pom.xml
 .lein-deps-sum
 .lein-failures
 .lein-plugins
+.nrepl-port
+.cpcache/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In order to add `docopt.clj` to the classpath, you can either
 - Use an environment variable
   ``` bash
   cd babashka
-  export BABASHKA_CLASSPATH=$(clojure -Spath -Sdeps '{:deps {docopt {:git/url "https://github.com/nubank/docopt.clj" :sha "12b997548381b607ddb246e4f4c54c01906e70aa"}}}')
+  export BABASHKA_CLASSPATH=$(clojure -Spath -Sdeps '{:deps {nubank/docopt {:git/url "https://github.com/nubank/docopt.clj" :sha "0c5b1c7645901affcda115fc280744f5f8dc802a"}}}')
   ./naval_fate_env.clj
   ```
 

--- a/babashka/naval_fate_dynamic.clj
+++ b/babashka/naval_fate_dynamic.clj
@@ -3,8 +3,8 @@
 (require '[babashka.classpath :refer [add-classpath]]
          '[clojure.java.shell :refer [sh]])
 
-(def docopt-dep '{:deps {docopt {:git/url "https://github.com/nubank/docopt.clj"
-                                 :sha     "12b997548381b607ddb246e4f4c54c01906e70aa"}}})
+(def docopt-dep '{:deps {nubank/docopt {:git/url "https://github.com/nubank/docopt.clj"
+                                        :sha     "0c5b1c7645901affcda115fc280744f5f8dc802a"}}})
 (def cp (:out (sh "clojure" "-Spath" "-Sdeps" (str docopt-dep))))
 (add-classpath cp)
 

--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,5 @@
   :url "http://docopt.org"
   :license {:name "MIT" :url "https://github.com/docopt/docopt.clj/blob/master/LICENSE"}
   :dependencies [[org.clojure/clojure "1.10.3"]]
-  :profiles {:dev {:dependencies [[org.clojure/data.json "2.2.1"]]}}
+  :profiles {:dev {:dependencies [[cheshire "5.10.0"]]}}
   :aot :all)

--- a/src/docopt/core.clj
+++ b/src/docopt/core.clj
@@ -14,11 +14,31 @@
     (u/parse (section "usage" s/split-lines) (o/parse (section "options" osplitfn)))))
 
 (defn docopt
+  "Parse `argv` based on command-line interface described in `doc`.
+
+  `docopt` creates your command-line interface based on its
+  description that you pass as `doc`. Such description can contain
+  --options, <positional-argument>, commands, which could be
+  [optional], (required), (mutually | exclusive) or repeated...
+
+  This function has multiple arities. The default one is the 2-arity
+  one.
+
+  `result-fn` is a function that will be called with the resulting
+  map after parsing `doc`+`argv`. By default in the 2 arity version
+  of this function, this will be set to `identity` function, i.e.:
+  will return the map without changes.
+
+  `usage-fn` is a function that will be called in case of issues
+  while parsing, and will receive the `doc` as argument. By default
+  in the 2/3 arity version of this function, this will be set to
+  `println`, i.e.: it will print the usage of the program and return
+  `nil`."
   ([doc args]
-   (docopt doc args identity println))
-  ([doc args f]
-   (docopt doc args f println))
-  ([doc args f print-fn]
+   (docopt doc args identity))
+  ([doc args result-fn]
+   (docopt doc args result-fn println))
+  ([doc args result-fn usage-fn]
    (if-let [arg-map (-> doc parse (m/match-argv args))]
-     (f arg-map)
-     (print-fn doc))))
+     (result-fn arg-map)
+     (usage-fn doc))))

--- a/src/docopt/match.clj
+++ b/src/docopt/match.clj
@@ -19,7 +19,7 @@
 (defn parse
   "Parses the command-line arguments into a matchable state [acc remaining-option-values remaining-words]."
   [{:keys [acc shorts-re longs-re]} argv]
-  (let [[head _ & tail] (partition-by (partial = "--") argv)
+  (let [[head & tail]   (partition-by (partial = "--") argv)
         options         (remove string? (keys acc))
         tokens          (mapcat #(expand % options) (tokenize (s/join " " head) 
                                                               (concat (map vector longs-re  (repeat :long-option))
@@ -71,15 +71,9 @@
      (= [] value) (if (vector? default-value) default-value [default-value])
      :else        value)])
 
-(defn- biggest-match
-  [matches]
-  (letfn [(filled-vals-count [match]
-            (->> match first vals (remove nil?) count))]
-    (->> matches (sort-by filled-vals-count >) first)))
-
-(defn match-argv 
+(defn match-argv
   "Match command-line arguments with usage patterns."
   [docmap argv]
   (if-let [state (parse docmap argv)]
-    (if-let [[match] (biggest-match (filter #(every? empty? (cons (% 2) (vals (% 1)))) (matches #{state} (:tree docmap))))]
+    (if-let [[match] (first (filter #(every? empty? (cons (% 2) (vals (% 1)))) (matches #{state} (:tree docmap))))]
       (into (sorted-map) (map #(if (string? (key %)) % (option-value %)) match)))))

--- a/src/docopt/usageblock.clj
+++ b/src/docopt/usageblock.clj
@@ -48,8 +48,7 @@
                      [#"(\)|\])"                           ::end-group]]
                     (map vector longs-re            (repeat :long-option)) 
                     (map vector shorts-re           (repeat :short-options))
-                    [[(re-tok "--")                         :args-separator]
-                     [(re-tok "--([^= ]+)=(<[^<>]*>|\\S+)") :long-option]
+                    [[(re-tok "--([^= ]+)=(<[^<>]*>|\\S+)") :long-option]
                      [(re-tok "--(\\S+)")                   :long-option]
                      [(re-tok "-(?!-)(\\S+)")               :short-options]
                      [(re-tok re-arg-str)                  ::argument]
@@ -70,7 +69,6 @@
   [[tag name arg :as token] lnum options] 
   tag
   ::token         [(into [tag lnum] (rest token))]
-  :args-separator [] ;; ignore
   :long-option    [(find-option :long name arg lnum options)]
   :short-options  (letfn [(new-short [arg c] (find-option :short (str c) arg lnum options))]
                     (conj (into [] (map (partial new-short nil) (butlast name)))

--- a/src/docopt/usageblock.clj
+++ b/src/docopt/usageblock.clj
@@ -10,7 +10,7 @@
 (defn partial-long-re-str 
   "Creates partial match pattern for long option name."
   [names re-str [c & more-c]]
-  (let [[match & more-matches :as matches] (filter #(= c (first %)) names)]
+  (let [[_match & more-matches :as matches] (filter #(= c (first %)) names)]
     (if (or (empty? more-matches) (empty? more-c))
       (apply str re-str c (interleave more-c (repeat \?)))
       (recur (filter seq (map rest matches)) (str re-str c) more-c))))
@@ -20,7 +20,7 @@
   [long-options pattern-parsing?]
   (let [longs (map :long long-options)]
     (into [] (map #(re-tok "--(" (if pattern-parsing? %1 (partial-long-re-str longs "" %1)) ")" %2)
-                  longs (map #(if (:takes-arg %) "(?:=| )(\\S+)") long-options)))))
+                  longs (map #(when (:takes-arg %) "(?:=| )(\\S+)") long-options)))))
 
 (defn compile-short-options-re  
   "Generates regexes to unambiguously capture short options, for usage pattern parsing or for argv matching."
@@ -57,11 +57,11 @@
 (defn find-option
   "Returns the corresponding option object in the 'options' sequence, or generates a new one."
   [name-key name arg lnum options]
-  (let [takes-arg (not (empty? arg))
+  (let [takes-arg (boolean (seq arg))
         [option] (filter #(= name (% name-key)) options)]
     (err (and option (not= takes-arg (:takes-arg option))) :parse
          "Usage line " lnum ": " (if (= name-key :short) "short" "long") " option '" (option name-key)
-         "'already defined with" (when takes-arg "out") " argument.")
+         "' already defined with" (when takes-arg "out") " argument.")
     [::option lnum (or option {name-key name :takes-arg takes-arg})]))
 
 (defmultimethods expand 
@@ -91,7 +91,7 @@
   (let [tokens              (tokenize-pattern-lines lines options-block-options)
         usage-block-options (reduce conj #{} (map #(% 2) (filter #(= ::option (% 0)) tokens)))
         options-diff        (remove usage-block-options options-block-options)]
-    (mapcat (fn [[tag lnum & more :as token]]
+    (mapcat (fn [[tag lnum & _ :as token]]
               (if (= tag ::options)
                 (concat [[::group lnum "["]] (map #(vector ::option lnum %) options-diff) [[::end-group lnum "]"]])
                 [token]))
@@ -149,7 +149,7 @@
 (defn syntax-tree
   "Generates syntax tree from token sequence." 
   [tokens]
-  (let [[tree & more :as stack] (reduce make-node [[[]]] (concat [[::group nil "("]] tokens [[::end-group nil ")"]]))]
+  (let [[_tree & more :as stack] (reduce make-node [[[]]] (concat [[::group nil "("]] tokens [[::end-group nil ")"]]))]
     (err (seq more) :parse "Missing ')' or ']'.")
     (or (peek-last stack) [])))
 

--- a/src/docopt/util.clj
+++ b/src/docopt/util.clj
@@ -5,7 +5,12 @@
 
 (defmacro err [err-clause type & err-strs]
   `(when ~err-clause
-     (throw (Exception. (str "DOCOPT ERROR " ~(case type :syntax "(syntax) " :parse "(parse) ") \| ~@err-strs)))))
+     (throw
+      (ex-info (str "DOCOPT ERROR "
+                    ~(case type :syntax "(syntax) " :parse "(parse) ")
+                    "| " ~@err-strs)
+               {:docopt.error/type    ~type
+                :docopt.error/msg     (str ~@err-strs)}))))
 
 (defmacro defmultimethods
   "Syntactic sugar for defmulti + multiple defmethods."

--- a/test/docopt/core_test.clj
+++ b/test/docopt/core_test.clj
@@ -1,5 +1,5 @@
 (ns docopt.core-test
-  (:require [clojure.data.json :as json]
+  (:require [cheshire.core :as json]
             [clojure.string :as s]
             [clojure.test :refer :all]
             [docopt.core :as d]
@@ -24,7 +24,7 @@
   [path] 
   (into [] (mapcat (fn [[_ doc tests]]
                    (map (fn [[_ args result]]
-                          [doc (into [] (filter seq (s/split (or args "") #"\s+"))) (json/read-str result)])
+                          [doc (into [] (filter seq (s/split (or args "") #"\s+"))) (json/parse-string result)])
                         (re-seq test-block-regex tests)))
                  (re-seq doc-block-regex (s/replace (slurp path) #"#.*" "")))))
 
@@ -37,8 +37,10 @@
       (str "\n" (s/trim-newline doc) "\n" docinfo)
       (let [result (or (m/match-argv docinfo in) "user-error")]
         (when (not= result out)
-          (str "\n" (s/trim-newline doc) "\n$ prog " (s/join " " in) 
-               "\nexpected: " (json/write-str out) "\nobtained: " (json/write-str result) "\n\n"))))))
+          (str "\n" (s/trim-newline doc)
+               "\n$ prog " (s/join " " in)
+               "\nexpected: " (json/generate-string out)
+               "\nobtained: " (json/generate-string result) "\n\n"))))))
 
 (defn valid?
   "Validates all test cases found in the file named 'test-cases-file-name'."

--- a/test/docopt/extra_testcases.docopt
+++ b/test/docopt/extra_testcases.docopt
@@ -10,7 +10,7 @@ $ prog foo
 "user-error"
 
 $ prog foo -- --bar
-{"--":true,"<extra-opts>":["--bar"],"foo":true}
+{"--":true, "<extra-opts>": ["--bar"], "foo":true}
 
 r"""Usage: prog foo [--] <extra-opts>...
 
@@ -22,9 +22,7 @@ $ prog foo
 # {"foo": true, "--": false, "<extra-opts>": []}
 
 $ prog foo -- --bar
-{"--":false,"<extra-opts>":["--","--bar"],"foo":true}
-# Wrong, should be
-# {"foo": true, "--": true, "<extra-opts>": ["--bar"]}
+{"foo": true, "--": true, "<extra-opts>": ["--bar"]}
 
 r"""Complex command
 
@@ -50,9 +48,7 @@ $ prog a b c d --foo --bar bar
 {"--":false,"--bar":"bar","--foo":true,"<extra>":[],"<param-a>":"a","<param-b>":"b","<param-c>":"c","<param-d>":"d","<param-x>":null,"<param-y>":null}
 
 $ prog x y --bar bar -- extra
-{"--":false,"--bar":"bar","--foo":false,"<extra>":[],"<param-a>":"x","<param-b>":"y","<param-c>":"--","<param-d>":"extra","<param-x>":null,"<param-y>":null}
-# Wrong, should be
-# {"--bar": "bar", "--foo": false, "<param-x>": "x", "<param-y>": "y", "--": true, "<extra>": ["extra"], "<param-a>": null, "<param-b>": null, "<param-c>": null, "<param-d>": null}
+{"--bar": "bar", "--foo": false, "<param-x>": "x", "<param-y>": "y", "--": true, "<extra>": ["extra"], "<param-a>": null, "<param-b>": null, "<param-c>": null, "<param-d>": null}
 
 $ prog a b c d --foo --bar bar -- extra
 {"--foo": true, "--bar": "bar", "<param-x>": null, "<param-y>": null, "--": true, "<extra>": ["extra"], "<param-a>": "a", "<param-b>": "b", "<param-c>": "c", "<param-d>": "d"}

--- a/test/docopt/extra_testcases.docopt
+++ b/test/docopt/extra_testcases.docopt
@@ -1,9 +1,30 @@
+# Should output the same things as docopt/docopt for language agnostic tests
+
+# Testing `--`
+
 r"""Usage: prog foo -- <extra-opts>...
 
 """
-$ prog foo -- --bar
-{"<extra-opts>":["--bar"],"foo":true}
 
+$ prog foo
+"user-error"
+
+$ prog foo -- --bar
+{"--":true,"<extra-opts>":["--bar"],"foo":true}
+
+r"""Usage: prog foo [--] <extra-opts>...
+
+"""
+
+$ prog foo
+"user-error"
+# Wrong, should be
+# {"foo": true, "--": false, "<extra-opts>": []}
+
+$ prog foo -- --bar
+{"--":false,"<extra-opts>":["--","--bar"],"foo":true}
+# Wrong, should be
+# {"foo": true, "--": true, "<extra-opts>": ["--bar"]}
 
 r"""Complex command
 
@@ -20,21 +41,21 @@ Options:
 """
 
 $ prog x y --foo
-{"--bar":null,"--foo":true,"<extra>":[],"<param-a>":null,"<param-b>":null,"<param-c>":null,"<param-d>":null,"<param-x>":"x","<param-y>":"y"}
+{"--":false,"--bar":null,"--foo":true,"<extra>":[],"<param-a>":null,"<param-b>":null,"<param-c>":null,"<param-d>":null,"<param-x>":"x","<param-y>":"y"}
 
 $ prog a b c d
-{"--bar":null,"--foo":false,"<extra>":[],"<param-a>":"a","<param-b>":"b","<param-c>":"c","<param-d>":"d","<param-x>":null,"<param-y>":null}
+{"--":false,"--bar":null,"--foo":false,"<extra>":[],"<param-a>":"a","<param-b>":"b","<param-c>":"c","<param-d>":"d","<param-x>":null,"<param-y>":null}
 
 $ prog a b c d --foo --bar bar
-{"--bar":"bar","--foo":true,"<extra>":[],"<param-a>":"a","<param-b>":"b","<param-c>":"c","<param-d>":"d","<param-x>":null,"<param-y>":null}
+{"--":false,"--bar":"bar","--foo":true,"<extra>":[],"<param-a>":"a","<param-b>":"b","<param-c>":"c","<param-d>":"d","<param-x>":null,"<param-y>":null}
 
 $ prog x y --bar bar -- extra
-{"--bar":"bar","--foo":false,"<extra>":["extra"],"<param-a>":null,"<param-b>":null,"<param-c>":null,"<param-d>":null,"<param-x>":"x","<param-y>":"y"}
+{"--":false,"--bar":"bar","--foo":false,"<extra>":[],"<param-a>":"x","<param-b>":"y","<param-c>":"--","<param-d>":"extra","<param-x>":null,"<param-y>":null}
+# Wrong, should be
+# {"--bar": "bar", "--foo": false, "<param-x>": "x", "<param-y>": "y", "--": true, "<extra>": ["extra"], "<param-a>": null, "<param-b>": null, "<param-c>": null, "<param-d>": null}
 
 $ prog a b c d --foo --bar bar -- extra
-{"--bar":"bar","--foo":true,"<extra>":["extra"],"<param-a>":"a","<param-b>":"b","<param-c>":"c","<param-d>":"d","<param-x>":null,"<param-y>":null}
+{"--foo": true, "--bar": "bar", "<param-x>": null, "<param-y>": null, "--": true, "<extra>": ["extra"], "<param-a>": "a", "<param-b>": "b", "<param-c>": "c", "<param-d>": "d"}
 
 $ prog x y -- e1 e2 e3 e4
-{"--bar":null,"--foo":false,"<extra>":["e3","e4"],"<param-a>":"x","<param-b>":"y","<param-c>":"e1","<param-d>":"e2","<param-x>":null,"<param-y>":null}
-# Wrong, this should be:
-# {"--bar":null,"--foo":false,"<extra>":["e1","e2","e3","e4"],"<param-a>":null,<param-b>":null,<param-c>":null,"<param-d>":null,<param-x>":"x","<param-y>":"y"}
+{"--bar": null, "--foo": false, "<param-x>": "x", "<param-y>": "y", "--": true, "<extra>": ["e1", "e2", "e3", "e4"], "<param-a>": null, "<param-b>": null, "<param-c>": null, "<param-d>": null}

--- a/test_runner.clj
+++ b/test_runner.clj
@@ -1,0 +1,34 @@
+#!/usr/bin/env bb
+
+(ns test-runner
+  (:require [clojure.test :as t]
+            [clojure.string :as string]
+            [babashka.classpath :as cp]
+            [babashka.fs :as fs]))
+
+(cp/add-classpath "src:test")
+
+(defn test-file->test-ns
+  [file]
+  (as-> file $
+        (fs/components $)
+        (drop 1 $)
+        (mapv str $)
+        (string/join "." $)
+        (string/replace $ #"_" "-")
+        (string/replace $ #".clj$" "")
+        (symbol $)))
+
+(def test-namespaces
+  (->> (fs/glob "test" "**/*_test.clj")
+       (mapv test-file->test-ns)))
+
+(apply require test-namespaces)
+
+(defn run-tests!
+  []
+  (let [{:keys [fail error]} (apply t/run-tests test-namespaces)]
+    (System/exit (+ fail error))))
+
+(when (= *file* (System/getProperty "babashka.file"))
+    (run-tests!))


### PR DESCRIPTION
This is a partial revert of commits:
- d2413b2 (ignore `--` in `docopt.usageblock/tokenize-pattern`)
- 6845163 (find biggest-match in `docopt.match/match-argv`)

The actual root cause of the issue while parsing `--` was the `docopt.match/parse` function. `docopt.usageoption/parse` seems correct, at least while parsing this:

```clojure
(parse "usage: prog foo -- <extra-opts>...")

:docopt.usageblock/required
[ :docopt.usageblock/command "foo" ]
[ :docopt.usageblock/command "--" ]
[ :docopt.usageblock/repeat [ :docopt.usageblock/argument "<extra-opts>" ] ]
```

As it is clear above, `--` is correctly parsed as a `:docopt.usageblock/command`. This is the same behavior as docopt/docopt, but commit d2413b2 broke this.

Reverting commit d2413b2 and now the issue is in `docopt.match/parse`, since it was ignoring `--` thanks to the `[head _ & tail] (partition-by (partial "--") argv)` part. Removing `_` and putting `--` at the tail seems to do the trick.

Compared to the previous trick, this fix some tests and breaks other ones. But I think the code as a whole now is more correctly, and the other issues can be fixed by other commits. Some of those tests that broke are fixed in the workaround implemented in commit f19d913.

Also, this commits brings more quality of life fixes:

- More lint fixes
- Add documentation to `docopt.core/docopt`
- Add `test_runner.clj` (to allow running tests with Babashka)
- Use `ex-info` in `docopt.utils/err` (this should make this library compatible with ClojureScript too, but didn't test it)