### PR TITLE
Workaround issue with spaces

### DIFF
--- a/src/docopt/match.clj
+++ b/src/docopt/match.clj
@@ -16,19 +16,42 @@
   :short-options (let [options (map (fn [c] (first (filter #(= (str c) (:short %)) options))) name)]
                    (concat (map array-map (butlast options) (repeat nil)) [{(last options) arg}])))
 
+(def ^:private space-sep
+  "Non-breaking space"
+  "\u00A0")
+
+(defn- spaces->spaces-seps
+  "Convert spaces to a space separator, so we don't lose args after parsing."
+  [head]
+  (map (fn [s]
+         (if (string? s)
+           (s/replace s #" " space-sep)
+           s))
+       head))
+
+(defn- spaces-seps->spaces
+  "Convert spaces to a space separator, so we don't lose args after parsing."
+  [head]
+  (map (fn [s]
+         (if (string? s)
+           (s/replace s (re-pattern space-sep) " ")
+           s))
+       head))
+
 (defn parse
   "Parses the command-line arguments into a matchable state [acc remaining-option-values remaining-words]."
   [{:keys [acc shorts-re longs-re]} argv]
   (let [[head & tail]   (partition-by (partial = "--") argv)
         options         (remove string? (keys acc))
-        tokens          (mapcat #(expand % options) (tokenize (s/join " " head) 
+        tokens          (mapcat #(expand % options) (tokenize (s/join " " (spaces->spaces-seps head))
                                                               (concat (map vector longs-re  (repeat :long-option))
                                                                       (map vector shorts-re (repeat :short-options))
-                                                                      [[(re-tok "-\\S+|(\\S+)")     :word]])))]
-    (when (not-any? nil? tokens)
+                                                                      [[(re-tok "-\\S+|(\\S+)")     :word]])))
+        tokens'         (spaces-seps->spaces tokens)]
+    (when (not-any? nil? tokens')
       [acc
-       (apply merge-with conj (zipmap options (repeat [])) (filter map? tokens))
-       (apply concat (filter string? tokens) tail)])))
+       (apply merge-with conj (zipmap options (repeat [])) (filter map? tokens'))
+       (apply concat (filter string? tokens') tail)])))
 
 ;; walk pattern tree
 

--- a/src/docopt/match.clj
+++ b/src/docopt/match.clj
@@ -3,6 +3,15 @@
             [clojure.string :as s]
             [docopt.util :refer [defmultimethods re-tok tokenize]]))
 
+(def ^:dynamic space-sep
+  "Workaround issue with spaces by converting them to another character.
+
+  See https://github.com/nubank/docopt.clj/pull/5 for details.
+
+  If you have issues with \u00A0, use `binding` to select another
+  separator character."
+  "\u00A0")
+
 ;; parse command line
 
 (defmultimethods expand 
@@ -15,10 +24,6 @@
                    [{(first (concat (filter exactfn options) (filter partialfn options))) arg}])
   :short-options (let [options (map (fn [c] (first (filter #(= (str c) (:short %)) options))) name)]
                    (concat (map array-map (butlast options) (repeat nil)) [{(last options) arg}])))
-
-(def ^:private space-sep
-  "Non-breaking space"
-  "\u00A0")
 
 (defn- spaces->spaces-seps
   "Convert spaces to a space separator, so we don't lose args after parsing."

--- a/test/docopt/core_test.clj
+++ b/test/docopt/core_test.clj
@@ -56,6 +56,18 @@
   (is (valid? "https://raw.github.com/docopt/docopt/511d1c57b59cd2ed663a9f9e181b5160ce97e728/testcases.docopt"))
   (is (valid? "test/docopt/extra_testcases.docopt"))
 
+  (testing "2-arity version"
+    (is (= {"<foo>" "a"}
+           (d/docopt "usage: prog <foo>" ["a"]))))
+
+  (testing "3-arity version"
+    (is (= "a"
+           (d/docopt "usage: prog <foo>" ["a"] #(get % "<foo>")))))
+
+  (testing "4-arity version"
+    (is (= "usage: prog <foo>"
+           (d/docopt "usage: prog <foo>" [] identity identity))))
+
   ;; Adding this test here since it seems testcases file doesn't support quoted args
   (testing "should parse quoted args correctly"
     (is (= {"<foo>" "a b"}

--- a/test/docopt/core_test.clj
+++ b/test/docopt/core_test.clj
@@ -54,4 +54,11 @@
 
 (deftest docopt-test
   (is (valid? "https://raw.github.com/docopt/docopt/511d1c57b59cd2ed663a9f9e181b5160ce97e728/testcases.docopt"))
-  (is (valid? "test/docopt/extra_testcases.docopt")))
+  (is (valid? "test/docopt/extra_testcases.docopt"))
+
+  ;; Adding this test here since it seems testcases file doesn't support quoted args
+  (testing "should parse quoted args correctly"
+    (is (= {"<foo>" "a b"}
+           (d/docopt "usage: prog <foo>" ["a b"])))
+    (is (= {"<foo>" "a   b c"}
+           (d/docopt "usage: prog <foo>" ["a   b c"])))))

--- a/test/docopt/core_test.clj
+++ b/test/docopt/core_test.clj
@@ -70,7 +70,10 @@
     (is (= {"<foo>" "a b"}
            (d/docopt "usage: prog <foo>" ["a b"])))
     (is (= {"<foo>" "a   b c"}
-           (d/docopt "usage: prog <foo>" ["a   b c"])))))
+           (d/docopt "usage: prog <foo>" ["a   b c"])))
+    (binding [docopt.match/space-sep "\u0000"]
+      (is (= {"<foo>" "a b    c"}
+             (d/docopt "usage: prog <foo>" ["a b    c"]))))))
 
 (deftest language-agnostic-test
   (is (valid? "https://raw.github.com/docopt/docopt/511d1c57b59cd2ed663a9f9e181b5160ce97e728/testcases.docopt"))

--- a/test/docopt/core_test.clj
+++ b/test/docopt/core_test.clj
@@ -53,9 +53,6 @@
     true))
 
 (deftest docopt-test
-  (is (valid? "https://raw.github.com/docopt/docopt/511d1c57b59cd2ed663a9f9e181b5160ce97e728/testcases.docopt"))
-  (is (valid? "test/docopt/extra_testcases.docopt"))
-
   (testing "2-arity version"
     (is (= {"<foo>" "a"}
            (d/docopt "usage: prog <foo>" ["a"]))))
@@ -74,3 +71,7 @@
            (d/docopt "usage: prog <foo>" ["a b"])))
     (is (= {"<foo>" "a   b c"}
            (d/docopt "usage: prog <foo>" ["a   b c"])))))
+
+(deftest language-agnostic-test
+  (is (valid? "https://raw.github.com/docopt/docopt/511d1c57b59cd2ed663a9f9e181b5160ce97e728/testcases.docopt"))
+  (is (valid? "test/docopt/extra_testcases.docopt")))


### PR DESCRIPTION
The parse has an issue that when we have something like:

```clojure
(docopt "usage: prog <foo>" ["a b"])
```

It will try to parse "a" and "b" as 2 separate arguments (and this will obviously fail).

Fixing the parse seems very hard, so let's do a workaround instead, converting spaces to `\u00A0` (non-breaking space). So for example, conveting "a b" to "a\u00A0b".

Ugly, but it works.